### PR TITLE
Load API keys from env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your API keys
+OPENAI_API_KEY=
+GEMINI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ An easy-to-use tool that automatically analyzes the relevance of academic papers
    ```
 
 3. **Add your API key**:
-   - Open `LitRelevance.py` in any text editor (like Notepad, TextEdit, or VS Code)
-   - Find this line near the top: `DEFAULT_API_KEY = ""` 
-   - Put your API key between the quotes: `DEFAULT_API_KEY = "your-api-key-here"`
-   - Save the file
+   - Copy `.env.example` to `.env`
+   - Fill in your OpenAI or Gemini API keys
+   - Scripts such as `abstractScreener` will automatically read these values
+   - For `LitRelevance.py`, you can alternatively set `DEFAULT_API_KEY` directly in the file
 
 ## How to Use the Tool
 

--- a/abstractScreener
+++ b/abstractScreener
@@ -1,10 +1,34 @@
 import pandas as pd
 import os
+from pathlib import Path
 from litellm import completion
 import openpyxl
 import time
 import json # 用于解析JSON响应
 import sys # 用于退出脚本
+
+
+def load_env_file(env_path: str = ".env") -> None:
+    """Load environment variables from a .env file if present.
+
+    This avoids hard-coding API keys in the script and allows users to
+    store them locally. Lines starting with ``#`` or without ``=`` are
+    ignored. Existing environment variables are not overwritten.
+    """
+
+    path = Path(env_path)
+    if not path.exists():
+        return
+
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+load_env_file()
 
 # GUI 相关库在需要时才导入，避免在纯命令行环境中引入不必要依赖
 


### PR DESCRIPTION
## Summary
- load API keys from a `.env` file at runtime
- document environment variable usage and provide an `.env.example`
- ignore `.env` and cache directories in git

## Testing
- `python -m py_compile abstractScreener`

------
https://chatgpt.com/codex/tasks/task_e_6890265b82fc8330a9f17c24e076f867