### PR TITLE
feat: centralize configuration and AI client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@
 ## Conventions
 - Prefer `rg` for searching the repository.
 - Keep documentation in both `README.md` and `Chinese_README.md` up to date with any CLI or packaging changes.
+- Use the shared `config` and `AIClient` utilities instead of reimplementing configuration loading or model calls.

--- a/Chinese_README.md
+++ b/Chinese_README.md
@@ -8,8 +8,9 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
 
 - **CSV 相关性分析**：`litrx csv` 读取 Scopus 导出的文件，为每篇文章打出 0–100 的相关性分数，并给出解释。
 - **摘要快速筛选**：`litrx abstract` 根据 `questions_config.json` 中的自定义问题进行是/否判定和开放式问题回答，`--gui` 参数可启动简易图形界面。
-- **PDF 筛选**：`litrx pdf` 将整篇论文发送给模型，依据研究问题和筛选标准输出结构化结果。
+ - **PDF 筛选**：`litrx pdf` 会先将 PDF 转为文本再发送给模型，依据研究问题和筛选标准输出结构化结果。
 - **灵活的模型配置**：可在脚本中自由切换 OpenAI 或 Gemini，并调整温度、模型名称等参数。
+- **统一的配置管理**：通过 `.env` 与 JSON/YAML 配置文件合并生成 `DEFAULT_CONFIG`，命令行参数可覆盖默认值。
 - **自动保存进度**：中间结果和最终结果都会写入带时间戳的 CSV 或 XLSX 文件，避免进度丢失。
 
 ## 安装步骤
@@ -31,6 +32,10 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
    ```
 3. 根据提示选择 API、输入研究主题并提供 CSV 路径，结果将保存在同目录下。
 
+## 配置说明
+
+所有命令会将 `.env` 与通过 `--config` 指定的 JSON/YAML 文件合并成 `DEFAULT_CONFIG`，命令行参数可进一步覆盖默认值。
+
 ## 高级工具
 
 - **摘要筛选**
@@ -41,15 +46,15 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
   修改 `questions_config.json` 可自定义筛选问题与列名。
 - **PDF 筛选**
   ```bash
-  litrx pdf --config path/to/config.json --pdf-folder path/to/pdfs
+  litrx pdf --config path/to/config.yml --pdf-folder path/to/pdfs
   ```
-  JSON 配置文件用于指定研究问题、筛选标准和输出格式。
+  JSON 或 YAML 配置文件用于指定研究问题、筛选标准和输出格式。
 
 ## 自定义建议
 
 - 在各脚本顶部修改默认模型或温度。
 - 编辑 `csv_analyzer.py` 中的提示词或 `questions_config.json` 中的问题以收集不同信息。
-- 通过 `.env` 或直接修改脚本设置 API 密钥。
+- 通过 `.env` 或提供配置文件来设置 API 密钥和其他默认参数。
 
 ## 许可协议
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ An AI-assisted toolkit that evaluates how well academic papers match your resear
 
 - **CSV relevance analysis** – `litrx csv` reads Scopus exports and scores each paper from 0–100 while explaining the connection to your research question.
 - **Configurable abstract screening** – `litrx abstract` applies yes/no criteria and open questions defined in `questions_config.json`. Add `--gui` to launch a minimal Tkinter interface.
-- **PDF screening** – `litrx pdf` sends full papers to the model, checks custom criteria and detailed questions, and saves structured results.
+ - **PDF screening** – `litrx pdf` converts papers to text before sending them to the model, checks custom criteria and detailed questions, and saves structured results.
 - **Flexible model support** – Choose between OpenAI or Gemini APIs, with model names and temperature easily customized in the scripts.
+- **Unified configuration** – `.env` values merge with JSON or YAML config files, and command-line options override the resulting `DEFAULT_CONFIG`.
 - **Automatic saving** – Interim and final results are written to CSV/XLSX files with timestamps so you never lose progress.
 
 ## Installation
@@ -31,6 +32,10 @@ An AI-assisted toolkit that evaluates how well academic papers match your resear
    ```
 3. Follow the prompts to choose API provider, enter your research topic, and supply the CSV path. Results are saved beside the input file.
 
+## Configuration
+
+All commands merge `.env` values with an optional JSON or YAML file passed via `--config`, producing a `DEFAULT_CONFIG` that command-line flags can override.
+
 ## Advanced Tools
 
 - **Abstract screening**
@@ -41,15 +46,15 @@ An AI-assisted toolkit that evaluates how well academic papers match your resear
   Edit `questions_config.json` to change screening questions or column names.
 - **PDF screening**
   ```bash
-  litrx pdf --config path/to/config.json --pdf-folder path/to/pdfs
+  litrx pdf --config path/to/config.yml --pdf-folder path/to/pdfs
   ```
-  The JSON config specifies research questions, screening criteria and output type.
+  The JSON or YAML config specifies research questions, screening criteria and output type.
 
 ## Customisation Tips
 
 - Modify default model names or temperature values at the top of the scripts.
 - Adjust the prompts in `csv_analyzer.py` or question sets in `questions_config.json` to collect different information.
-- Use `.env` or edit the scripts directly to set API keys.
+- Use `.env` or supply a config file to set API keys and other defaults.
 
 ## License
 

--- a/litrx/ai_client.py
+++ b/litrx/ai_client.py
@@ -1,0 +1,44 @@
+"""Simple AI client wrapper for OpenAI and Gemini via LiteLLM."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from litellm import completion
+
+
+class AIClient:
+    """Initialise API credentials and send requests through LiteLLM."""
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        service = config.get("AI_SERVICE", "openai")
+        model = config.get("MODEL_NAME", "gpt-4o")
+        api_base = config.get("API_BASE") or os.getenv("API_BASE")
+        if api_base:
+            os.environ["OPENAI_BASE_URL"] = api_base
+
+        if service == "openai":
+            api_key = config.get("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise RuntimeError("OpenAI API密钥未配置。")
+            os.environ["OPENAI_API_KEY"] = api_key
+        elif service == "gemini":
+            api_key = config.get("GEMINI_API_KEY") or os.getenv("GEMINI_API_KEY")
+            if not api_key:
+                raise RuntimeError("Gemini API密钥未配置。")
+            os.environ["GEMINI_API_KEY"] = api_key
+        else:
+            raise RuntimeError(
+                f"无效的AI服务 '{service}'。必须是 'openai' 或 'gemini'。"
+            )
+
+        self.model = model
+
+    def request(self, messages: List[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
+        """Send a chat completion request and return the raw response."""
+
+        try:
+            return completion(model=self.model, messages=messages, **kwargs)
+        except Exception as e:  # pragma: no cover - passthrough to caller
+            raise RuntimeError(f"AI 请求失败: {e}") from e

--- a/litrx/config.py
+++ b/litrx/config.py
@@ -1,0 +1,68 @@
+"""Configuration utilities for LitRelevanceAI.
+
+This module centralizes loading environment variables from a `.env` file
+and reading configuration from JSON or YAML files. It exposes a
+``DEFAULT_CONFIG`` dictionary with common AI settings which individual
+scripts can extend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback if pyyaml missing
+    yaml = None
+
+# Base configuration shared across scripts.
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "AI_SERVICE": "openai",  # or "gemini"
+    "MODEL_NAME": "gpt-4o",
+    "OPENAI_API_KEY": "",
+    "GEMINI_API_KEY": "",
+    "API_BASE": "",
+}
+
+def load_env_file(env_path: str = ".env") -> None:
+    """Load environment variables from a .env file if present."""
+
+    path = Path(env_path)
+    if not path.exists():
+        return
+
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip())
+
+def load_config(path: Optional[str], default: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Load configuration from a JSON or YAML file and merge with defaults."""
+
+    config: Dict[str, Any] = (default or DEFAULT_CONFIG).copy()
+    if not path:
+        return config
+
+    file_path = Path(path)
+    if not file_path.is_file():
+        return config
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            if file_path.suffix.lower() in {".yaml", ".yml"}:
+                if yaml is None:
+                    raise RuntimeError("pyyaml is required to read YAML files")
+                user_cfg = yaml.safe_load(f) or {}
+            else:
+                user_cfg = json.load(f)
+        if isinstance(user_cfg, dict):
+            config.update(user_cfg)
+    except Exception as e:
+        raise RuntimeError(f"Failed to load config file {path}: {e}")
+
+    return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "litellm",
     "tqdm",
     "openpyxl",
+    "pyyaml",
+    "pypdf",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add shared `config` module for .env and JSON/YAML settings
- introduce `AIClient` wrapper for OpenAI/Gemini via LiteLLM
- refactor CSV, abstract, and PDF tools to use shared helpers and mention YAML configs in docs
- convert PDFs to text before sending to the model and document the change
- document shared configuration and AI client usage across English and Chinese guides

## Testing
- `python -m pip install -e .`
- `litrx --help` *(fails: command not found)*
- `python -m litrx.cli --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b28241b0c883309248837a28825cd8