### PR TITLE
feat: centralize configuration and templates

### DIFF
--- a/Chinese_README.md
+++ b/Chinese_README.md
@@ -7,7 +7,7 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
 ## 功能特点
 
 - **CSV 相关性分析**：`litrx csv` 读取 Scopus 导出的文件，为每篇文章打出 0–100 的相关性分数，并给出解释。
-- **摘要快速筛选**：`litrx abstract` 根据 `questions_config.json` 中的自定义问题进行是/否判定和开放式问题回答，`--gui` 参数可启动简易图形界面。
+- **摘要快速筛选**：`litrx abstract` 根据 `configs/questions/abstract.yaml` 中的自定义问题进行是/否判定和开放式问题回答，`--gui` 参数可启动简易图形界面。
 - **PDF 筛选**：`litrx pdf` 会先将 PDF 转为文本再发送给模型，依据研究问题和筛选标准输出结构化结果。
 - **统一图形界面**：运行 `python -m litrx --gui` 可打开带标签页的窗口，集中进行 CSV 相关性分析、摘要筛选与 PDF 筛选。
 - **灵活的模型配置**：可在脚本中自由切换 OpenAI 或 Gemini，并调整温度、模型名称等参数。
@@ -49,7 +49,7 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
   litrx abstract            # 命令行模式
   litrx abstract --gui      # 图形界面模式
   ```
-  修改 `questions_config.json` 可自定义筛选问题与列名。
+  修改 `configs/questions/` 下的文件可自定义筛选问题与列名。
 - **PDF 筛选**
   ```bash
   litrx pdf --config path/to/config.yml --pdf-folder path/to/pdfs
@@ -59,7 +59,7 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
 ## 自定义建议
 
 - 在各脚本顶部修改默认模型或温度。
-- 编辑 `csv_analyzer.py` 中的提示词或 `questions_config.json` 中的问题以收集不同信息。
+- 编辑 `csv_analyzer.py` 中的提示词或 `configs/questions/` 中的问题以收集不同信息。
 - 通过 `.env` 或提供配置文件来设置 API 密钥和其他默认参数。
 
 ## 许可协议

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An AI-assisted toolkit that evaluates how well academic papers match your resear
 ## Features
 
 - **CSV relevance analysis** – `litrx csv` reads Scopus exports and scores each paper from 0–100 while explaining the connection to your research question.
-- **Configurable abstract screening** – `litrx abstract` applies yes/no criteria and open questions defined in `questions_config.json`. Add `--gui` to launch a minimal Tkinter interface.
+- **Configurable abstract screening** – `litrx abstract` applies yes/no criteria and open questions defined in `configs/questions/abstract.yaml`. Add `--gui` to launch a minimal Tkinter interface.
 - **PDF screening** – `litrx pdf` converts papers to text before sending them to the model, checks custom criteria and detailed questions, and saves structured results.
 - **Unified GUI** – `python -m litrx --gui` launches a tabbed window combining CSV analysis, abstract screening and PDF screening.
 - **Flexible model support** – Choose between OpenAI or Gemini APIs, with model names and temperature easily customized in the scripts.
@@ -40,7 +40,7 @@ An AI-assisted toolkit that evaluates how well academic papers match your resear
 
 ## Configuration
 
-All commands merge `.env` values with an optional JSON or YAML file passed via `--config`, producing a `DEFAULT_CONFIG` that command-line flags can override.
+All commands merge `.env` values with an optional JSON or YAML file passed via `--config`, producing a `DEFAULT_CONFIG` that command-line flags can override. Default settings and question templates live under `configs/`.
 
 ## Advanced Tools
 
@@ -49,17 +49,17 @@ All commands merge `.env` values with an optional JSON or YAML file passed via `
   litrx abstract            # command-line mode
   litrx abstract --gui      # graphical mode
   ```
-  Edit `questions_config.json` to change screening questions or column names.
+  Edit files in `configs/questions/` to change screening questions or column names.
 - **PDF screening**
   ```bash
   litrx pdf --config path/to/config.yml --pdf-folder path/to/pdfs
   ```
-  The JSON or YAML config specifies research questions, screening criteria and output type.
+  The JSON or YAML config specifies research questions, screening criteria and output type. Question templates default to the YAML files in `configs/questions/`.
 
 ## Customisation Tips
 
 - Modify default model names or temperature values at the top of the scripts.
-- Adjust the prompts in `csv_analyzer.py` or question sets in `questions_config.json` to collect different information.
+- Adjust the prompts in `csv_analyzer.py` or question sets in `configs/questions/` to collect different information.
 - Use `.env` or supply a config file to set API keys and other defaults.
 
 ## License

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,5 @@
+AI_SERVICE: openai
+MODEL_NAME: gpt-4o
+OPENAI_API_KEY: ""
+GEMINI_API_KEY: ""
+API_BASE: ""

--- a/configs/questions/abstract.yaml
+++ b/configs/questions/abstract.yaml
@@ -1,0 +1,14 @@
+open_questions:
+  - key: research_area
+    question: "这篇文献的主要研究领域是什么？"
+    column_name: "研究领域"
+  - key: methodology
+    question: "研究使用了什么主要方法？"
+    column_name: "研究方法"
+yes_no_questions:
+  - key: consumer_behavior
+    question: "这篇文献是否与消费者行为相关？"
+    column_name: "消费者行为相关"
+  - key: empirical_study
+    question: "这是否为实证研究？"
+    column_name: "实证研究"

--- a/configs/questions/csv.yaml
+++ b/configs/questions/csv.yaml
@@ -1,0 +1,8 @@
+open_questions:
+  - key: relation_summary
+    question: "概述该文献与研究主题的关联。"
+    column_name: "关联摘要"
+yes_no_questions:
+  - key: include_review
+    question: "是否应纳入综述？"
+    column_name: "纳入综述"

--- a/configs/questions/pdf.yaml
+++ b/configs/questions/pdf.yaml
@@ -1,0 +1,8 @@
+open_questions:
+  - key: main_findings
+    question: "主要研究发现是什么？"
+    column_name: "主要发现"
+yes_no_questions:
+  - key: field_study
+    question: "是否为field study？"
+    column_name: "是否田野研究"

--- a/litrx/ai_client.py
+++ b/litrx/ai_client.py
@@ -3,9 +3,26 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from litellm import completion
+
+from .config import DEFAULT_CONFIG as BASE_CONFIG, load_config as base_load_config
+
+
+def load_config(path: Optional[str] = None) -> Dict[str, Any]:
+    """Load AI client configuration.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a YAML/JSON config file. When omitted, the default
+        configuration under ``configs/config.yaml`` is used.
+    """
+
+    default_path = Path(__file__).resolve().parent.parent / "configs" / "config.yaml"
+    return base_load_config(str(path or default_path), BASE_CONFIG)
 
 
 class AIClient:

--- a/litrx/gui/main_window.py
+++ b/litrx/gui/main_window.py
@@ -11,7 +11,7 @@ from ..config import DEFAULT_CONFIG as BASE_CONFIG, load_env_file
 from ..ai_client import AIClient
 from ..csv_analyzer import LiteratureAnalyzer
 from ..abstract_screener import (
-    get_user_inputs_from_config,
+    load_config as load_abs_config,
     load_and_validate_data,
     prepare_dataframe,
     analyze_article,
@@ -168,9 +168,9 @@ class MainWindow:
         config['CONFIG_MODE'] = mode
         try:
             client = AIClient(config)
-            params = get_user_inputs_from_config(config)
-            open_q = params['open_questions']
-            yes_no_q = params['yes_no_questions']
+            _, q = load_abs_config()
+            open_q = q.get('open_questions', [])
+            yes_no_q = q.get('yes_no_questions', [])
             df, title_col, abstract_col = load_and_validate_data(path, config)
             df = prepare_dataframe(df, open_q, yes_no_q)
             total = len(df)


### PR DESCRIPTION
## Summary
- add configurable defaults and question templates under `configs/`
- expose `load_config` helpers for AI client and screening modules
- document new configuration layout in both READMEs

## Testing
- `python -m pip install -e .`
- `python -m litrx --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b28c1687508330b0c1e89832d134bf