### PR TITLE
feat(gui): add persistent config support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Prefer `rg` for searching the repository.
 - Keep documentation in both `README.md` and `Chinese_README.md` up to date with any CLI or packaging changes.
 - Use the shared `config` and `AIClient` utilities instead of reimplementing configuration loading or model calls.
+- GUI configuration loads defaults from `configs/config.yaml`, then merges `~/.litrx_gui.yaml` (written by the **Save Config** button) and `.env` in that order of priority.
 - When modifying the GUI, use `BaseWindow` for shared controls and add new tabs under `litrx/gui/tabs/`, registering them with `LitRxApp`.
 - The CSV analysis tab renders results in a `ttk.Treeview` with title, relevance, and analysis columns, supports exporting results, and opens full analyses on double-click.
 - The abstract screening tab loads questions from `configs/questions/abstract.yaml`, provides an editor for yes/no and open questions, logs model summaries in a read-only area, allows cancelling with a stop button, and exports the DataFrame to CSV or Excel.

--- a/Chinese_README.md
+++ b/Chinese_README.md
@@ -44,6 +44,8 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
 
 图形界面提供 **“保存配置”** 按钮，可将当前的 `AI_SERVICE`、`MODEL_NAME`、`API_BASE` 等设置写入 `~/.litrx_gui.yaml`。应用启动时会依次加载 `configs/config.yaml`、该持久化文件与 `.env`，优先级从低到高为 `~/.litrx_gui.yaml` < `.env` < 运行时输入，界面会自动填充保存的偏好。
 
+这些参数的基础默认值定义在 `configs/config.yaml`，如需调整启动时的初始设置，可修改此文件。
+
 ## 高级工具
 
 - **摘要筛选**

--- a/Chinese_README.md
+++ b/Chinese_README.md
@@ -42,6 +42,8 @@ AI 辅助的文献筛选工具，可评估学术论文与研究主题的相关�
 
 所有命令会将 `.env` 与通过 `--config` 指定的 JSON/YAML 文件合并成 `DEFAULT_CONFIG`，命令行参数可进一步覆盖默认值。
 
+图形界面提供 **“保存配置”** 按钮，可将当前的 `AI_SERVICE`、`MODEL_NAME`、`API_BASE` 等设置写入 `~/.litrx_gui.yaml`。应用启动时会依次加载 `configs/config.yaml`、该持久化文件与 `.env`，优先级从低到高为 `~/.litrx_gui.yaml` < `.env` < 运行时输入，界面会自动填充保存的偏好。
+
 ## 高级工具
 
 - **摘要筛选**

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ An AI-assisted toolkit that evaluates how well academic papers match your resear
 
 All commands merge `.env` values with an optional JSON or YAML file passed via `--config`, producing a `DEFAULT_CONFIG` that command-line flags can override. Default settings and question templates live under `configs/`.
 
+When running the GUI, a **Save Config** button writes the current `AI_SERVICE`, `MODEL_NAME`, `API_BASE` and API keys to `~/.litrx_gui.yaml`. On startup the application loads `configs/config.yaml`, the saved file, and `.env` in order of increasing priority (`~/.litrx_gui.yaml` < `.env` < runtime input), so your saved preferences populate the interface automatically.
+
 ## Advanced Tools
 
 - **Abstract screening**

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ All commands merge `.env` values with an optional JSON or YAML file passed via `
 
 When running the GUI, a **Save Config** button writes the current `AI_SERVICE`, `MODEL_NAME`, `API_BASE` and API keys to `~/.litrx_gui.yaml`. On startup the application loads `configs/config.yaml`, the saved file, and `.env` in order of increasing priority (`~/.litrx_gui.yaml` < `.env` < runtime input), so your saved preferences populate the interface automatically.
 
+The base defaults for these values live in `configs/config.yaml`; edit this file if you need to change the starting GUI settings before saving.
+
 ## Advanced Tools
 
 - **Abstract screening**


### PR DESCRIPTION
## Summary
- load configs/config.yaml, GUI save file, and .env with proper priority in BaseWindow
- add "Save Config" button writing AI settings to `~/.litrx_gui.yaml`
- document configuration persistence in README and Chinese README

## Testing
- `python -m pip install -e .`
- `python -m litrx --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3ca3ea4e08330811bd27eec8008ed